### PR TITLE
chore: restructure project as mono-repo for subsequent pw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .idea/modules.xml
 .idea/jpa-buddy.xml
 .idea/workspace.xml
+.idea/uiDesigner.xml
 *.iws
 *.iml
 *.ipr

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding">
-    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
-    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/dai-parent/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/dai-parent/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/pw-hello-world/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/pw-hello-world/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,13 +3,13 @@
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>
+        <option value="$PROJECT_DIR$/dai-dependencies/pom.xml" />
+        <option value="$PROJECT_DIR$/dai-parent/pom.xml" />
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17 (2)" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/out" />
-  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
   <component name="ProjectType">
     <option name="id" value="jpab" />
   </component>

--- a/.idea/runConfigurations/Package_hello_world.xml
+++ b/.idea/runConfigurations/Package_hello_world.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Package JAR" type="MavenRunConfiguration" factoryName="Maven">
+  <configuration default="false" name="Package hello-world" type="MavenRunConfiguration" factoryName="Maven">
     <MavenSettings>
       <option name="myGeneralSettings">
         <MavenGeneralSettings>
@@ -29,10 +29,11 @@
           </option>
           <option name="goals">
             <list>
-              <option value="dependency:resolve" />
               <option value="clean" />
-              <option value="compile" />
               <option value="package" />
+              <option value="-pl" />
+              <option value="pw-hello-world" />
+              <option value="-am" />
             </list>
           </option>
           <option name="pomFileName" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# HEIG-VD DAI 2023/24 - Practical Work by @lutonite

--- a/dai-dependencies/pom.xml
+++ b/dai-dependencies/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ch.lutonite.heig.dai</groupId>
+    <artifactId>dai-dependencies</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>Common dependency management for the DAI practical work modules</description>
+
+    <scm>
+        <url>https://github.com/Lutonite/heig-dai-2023-pw</url>
+    </scm>
+
+    <properties>
+        <!-- Libraries -->
+        <logback.version>1.4.11</logback.version>
+        <lombok.version>1.18.28</lombok.version>
+        <picocli.version>4.7.5</picocli.version>
+
+        <!-- Plugins -->
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- CLI -->
+            <dependency>
+                <groupId>info.picocli</groupId>
+                <artifactId>picocli</artifactId>
+                <version>${picocli.version}</version>
+            </dependency>
+
+            <!-- Utilities -->
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${maven-assembly-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/dai-parent/pom.xml
+++ b/dai-parent/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.lutonite.heig.dai</groupId>
+        <artifactId>dai-dependencies</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../dai-dependencies</relativePath>
+    </parent>
+
+    <artifactId>dai-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>Parent module for common configuration (like packaging as JARs)</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <manifest.main-class>ch.lutonite.heig.dai.module.Main</manifest.main-class>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>${manifest.main-class}</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>
+                </configuration>
+                <inherited>false</inherited>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,67 +4,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ch.heigvd</groupId>
+    <groupId>ch.lutonite.heigvd.dai</groupId>
     <artifactId>practical-work</artifactId>
-    <version>0.0.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <description>Parent module for packaging all individual practical works as one.</description>
 
-        <maven.jar.version>3.3.0</maven.jar.version>
-        <maven.shade.version>3.5.0</maven.shade.version>
-        <lombok.version>1.18.28</lombok.version>
-        <logback.version>1.4.11</logback.version>
-    </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.version}</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>ch.heigvd.Main</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven.shade.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>ch.heigvd.Main</mainClass>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <modules>
+        <!-- basis -->
+        <module>dai-dependencies</module>
+        <module>dai-parent</module>
+        <!-- utils -->
+        <!-- modules -->
+        <module>pw-hello-world</module>
+   </modules>
 </project>

--- a/pw-hello-world/pom.xml
+++ b/pw-hello-world/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ch.lutonite.heig.dai</groupId>
+        <artifactId>dai-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../dai-parent</relativePath>
+    </parent>
+
+    <artifactId>pw-hello-world</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <manifest.main-class>ch.lutonite.heig.dai.helloworld.Main</manifest.main-class>
+    </properties>
+</project>

--- a/pw-hello-world/src/main/java/ch/lutonite/heig/dai/helloworld/Main.java
+++ b/pw-hello-world/src/main/java/ch/lutonite/heig/dai/helloworld/Main.java
@@ -1,9 +1,10 @@
-package ch.heigvd;
+package ch.lutonite.heig.dai.helloworld;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class Main {
+
     public static void main(String[] args) {
         log.debug("Hello World!");
     }


### PR DESCRIPTION
> **Note**
> I have decided to use `maven-assembly-plugin` for packaging the JAR files, as it does not modify the dependencies, which is a step that is not needed when building application-like JARs.
> We would need to shade dependencies into our JARs only if they were meant to be used themselves as depdencies, which they dont.
> So, with this solution, we will only package dependencies into the JAR to be used as is.

closes #1